### PR TITLE
Update languages/fr.js

### DIFF
--- a/languages/fr.js
+++ b/languages/fr.js
@@ -12,7 +12,7 @@
             million: 'm'
         },
         ordinal : function (number) {
-            return number === 1 ? 'er' : 'ème';
+            return number === 1 ? 'er' : 'e';
         },
         currency: {
             symbol: '€'


### PR DESCRIPTION
the right typographic in « Règles typographiques en usage à l'imprimerie nationale » (p. 6)
Why don't format ordinal with <sup> </sup>
Before unit or currency how to use Narrow No-Break Space &#8239; ou &#x202F; ?
