### PR TITLE
AMD define() compatibility.

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -472,7 +472,7 @@
 
     /*global define:false */
     if (typeof define === 'function' && define.amd) {
-        define([], function () {
+        define('numeral', function () {
             return numeral;
         });
     }


### PR DESCRIPTION
According to the manual of AMD the first parameter of define() should be
an ID. String, not array.
https://github.com/amdjs/amdjs-api/wiki/AMD

This was biting with our production code which uses RequireJS.

ps. You will probably need to make the minified version and update the version number and stuff. I did not do this yet in my pull request because I don't know what minification tool you want to use.
