### PR TITLE
Chain with language('lang')

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -363,7 +363,7 @@
             loadLanguage(key, values);
         }
 
-        return languages;
+        return numeral;
     };
 
     numeral.language('en', {


### PR DESCRIPTION
`language` method send back numeral object on set.

With this, we can do:

<pre>
numeral.language('fr')(1500.152).format('0,0.0[0]');
numeral.language('en')(1500.152).format('0,0.0[0]');
</pre>


Instead of:

<pre>
numeral.language('fr');
numeral(1500.152).format('0,0.0[0]');
numeral.language('en');
numeral(1500.152).format('0,0.0[0]');
</pre>


Ah...and...nice work and thanks for this awesome library! :+1: 
