### PR TITLE
add support for fr-ch

### DIFF
--- a/languages/fr-ch.js
+++ b/languages/fr-ch.js
@@ -1,0 +1,32 @@
+// numeral.js language configuration
+// language : french (fr-ch)
+// author : Adam Draper : https://github.com/adamwdraper
+(function () {
+    var language = {
+        delimiters: {
+            thousands: '\'',
+            decimal: '.'
+        },
+        abbreviations: {
+            thousand: 'k',
+            million: 'm',
+            billion: 'b',
+            trillion: 't'
+        },
+        ordinal : function (number) {
+            return number === 1 ? 'er' : 'e';
+        },
+        currency: {
+            symbol: 'CHE'
+        }
+    };
+
+    // Node
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = language;
+    }
+    // Browser
+    if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
+        this.numeral.language('fr-ch', language);
+    }
+}());

--- a/languages/min/fr-ch.js
+++ b/languages/min/fr-ch.js
@@ -1,0 +1,4 @@
+// numeral.js language configuration
+// language : french (fr-ch)
+// author : Adam Draper : https://github.com/adamwdraper
+(function(){var language={delimiters:{thousands:"'",decimal:"."},abbreviations:{thousand:"k",million:"m",billion:"b",trillion:"t"},ordinal:function(number){return number===1?"er":"e"},currency:{symbol:"CHE"}};if(typeof module!=="undefined"&&module.exports){module.exports=language}if(typeof window!=="undefined"&&this.numeral&&this.numeral.language){this.numeral.language("fr-ch",language)}})();

--- a/tests/languages/fr-ch.js
+++ b/tests/languages/fr-ch.js
@@ -1,0 +1,77 @@
+module('Language: fr-ch', {
+    setup: function() {
+        numeral.language('fr-ch');
+    }
+});
+
+// Numbers -----------------------
+test('Format Numbers', 15, function() {
+    var tests = [
+        [10000,'0,0.0000','10\'000.0000'],
+        [10000.23,'0,0','10\'000'],
+        [-10000,'0,0.0','-10\'000.0'],
+        [10000.1234,'0.000','10000.123'],
+        [-10000,'(0,0.0000)','(10\'000.0000)'],
+        [-.23,'.00','-.23'],
+        [-.23,'(.00)','(.23)'],
+        [.23,'0.00000','0.23000'],
+        [1230974,'0.0a','1.2m'],
+        [1460,'0a','1k'],
+        [-104000,'0a','-104k'],
+        [1,'0o','1er'],
+        [52,'0o','52e'],
+        [23,'0o','23e'],
+        [100,'0o','100e']
+    ];
+
+    for (var i = 0; i < tests.length; i++) {
+        strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+    }
+});
+
+// Currency -----------------------
+test('Format Currency', 4, function() {
+    var tests = [
+        [1000.234,'$0,0.00','CHE1\'000.23'],
+        [-1000.234,'($0,0)','(CHE1\'000)'],
+        [-1000.234,'$0.00','-CHE1000.23'],
+        [1230974,'($0.00a)','CHE1.23m']
+    ];
+
+    for (var i = 0; i < tests.length; i++) {
+        strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+    }
+});
+
+// Percentages -----------------------
+test('Format Percentages', 4, function() {
+    var tests = [
+        [1,'0%','100%'],
+        [.974878234,'0.000%','97.488%'],
+        [-.43,'0%','-43%'],
+        [.43,'(0.000%)','43.000%']
+    ];
+
+    for (var i = 0; i < tests.length; i++) {
+        strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+    }
+});
+
+// Unformat ------------------------
+test('Unformat', 9, function() {
+    var tests = [
+        ['10\'000.123',10000.123],
+        ['(0.12345)',-.12345],
+        ['(CHE1.23m)',-1230000],
+        ['10k',10000],
+        ['-10k',-10000],
+        ['23e',23],
+        ['CHE10\'000.00',10000],
+        ['-76%',-.76],
+        ['2:23:57',8637]
+    ];
+
+    for (var i = 0; i < tests.length; i++) {
+        strictEqual(numeral().unformat(tests[i][0]), tests[i][1], tests[i][0]);
+    }
+});

--- a/tests/test.html
+++ b/tests/test.html
@@ -24,6 +24,7 @@
     <script src="../languages/en-gb.js"></script>
     <script src="../languages/fi.js"></script>
     <script src="../languages/fr.js"></script>
+    <script src="../languages/fr-ch.js"></script>
     <script src="../languages/es.js"></script>
     <script src="../languages/pt-pt.js"></script>
     <script src="../languages/cs.js"></script>
@@ -347,6 +348,7 @@
     <script type="text/javascript" src="languages/en-gb.js"></script>
     <script type="text/javascript" src="languages/fi.js"></script>
     <script type="text/javascript" src="languages/fr.js"></script>
+    <script type="text/javascript" src="languages/fr-ch.js"></script>
     <script type="text/javascript" src="languages/es.js"></script>
     <script type="text/javascript" src="languages/pt-pt.js"></script>
     <script type="text/javascript" src="languages/cs.js"></script>


### PR DESCRIPTION
added support for switzerland french.
there is an issue though
they use `'` as thousands delimiter. it's ok with formatting numbers but when i try to unformat string i get `NaN`
this is obviously due to regex that leaves `'` in initial string https://github.com/adamwdraper/Numeral-js/blob/master/numeral.js#L109

``` javascript
string.replace(/[^0-9\.'-]+/g, '')
```

and hence `Number('1\'000')` returns `NaN`
not sure what is that for,  so i just left it as it was
