### PR TITLE
French thousand separator = non breaking space

### DIFF
--- a/languages/fr.js
+++ b/languages/fr.js
@@ -6,7 +6,7 @@
 (function () {
     var language = {
         delimiters: {
-            thousands: ' ',
+            thousands: '\u00A0',
             decimal: ','
         },
         abbreviations: {


### PR DESCRIPTION
According to http://www.academie-francaise.fr/la-langue-francaise/questions-de-langue -> "Écriture des nombres en chiffres", the french thousand separator is a non breaking space.
