### PR TITLE
Fix IETF language tag lookup

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -419,6 +419,8 @@
         if (!key) {
             return currentLanguage;
         }
+        
+        key = key.toLowerCase();
 
         if (key && !values) {
             if(!languages[key]) {


### PR DESCRIPTION
Hello, when NumeralJS is saving or looking up an IETF language tag to add or get a language it's performing a case-sensitive comparison.

The problem is NumeralJS language files are using a mix of conventions for the language tags: some are lower case, some are upper case and others are mixed case.

This is causing a troubles for us because we're supplying the language tag dynamically from our back-end (specifically the ASP.NET current UI culture) which has no way to know how NumeralJS wants the language tag.

This fix normalizes the language tag when it's added to the internal dictionary to make look-ups case-insensitive.

The IETF standard saying the language tags must not be treated as case sensitive: http://tools.ietf.org/html/bcp47#section-2.2.1
