### PR TITLE
Correct abbreviations for Czech language

### DIFF
--- a/languages/cs.js
+++ b/languages/cs.js
@@ -12,8 +12,8 @@
         abbreviations: {
             thousand: 'tis.',
             million: 'mil.',
-            billion: 'b',
-            trillion: 't'
+            billion: 'mld.',
+            trillion: 'bil.'
         },
         ordinal: function () {
             return '.';


### PR DESCRIPTION
In Czech Republic, we have a slightly different naming. This is the correct form.
