### PR TITLE
Swedish translation: sv.js

### DIFF
--- a/languages/sv.js
+++ b/languages/sv.js
@@ -1,0 +1,34 @@
+/*! 
+ * numeral.js language configuration
+ * language : Swedish
+ * author : Juha-Jarmo Heinonen : https://github.com/jammi
+ */
+(function () {
+    var language = {
+        delimiters: {
+            thousands: ' ',
+            decimal: ','
+        },
+        abbreviations: {
+            thousand: 'k',
+            million: 'M',
+            billion: 'G',
+            trillion: 'T'
+        },
+        ordinal: function (number) {
+            return '.';
+        },
+        currency: {
+            symbol: 'kr'
+        }
+    };
+
+    // Node
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = language;
+    }
+    // Browser
+    if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
+        this.numeral.language('sv', language);
+    }
+}());


### PR DESCRIPTION
Swedish translation, is almost the same as the Finnish one (fi.js). The difference is just the currency "symbol".
