### PR TITLE
Add ordinal keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format",
     "time",
     "money",
-    "percentage"
+    "percentage",
+    "ordinal"
   ],
   "main": "./numeral.js",
   "engines": {


### PR DESCRIPTION
I was surprised numeral was not higher in the search for "ordinal" on npm.
