### PR TITLE
Added Swedish language.

### DIFF
--- a/languages/sv.js
+++ b/languages/sv.js
@@ -1,0 +1,35 @@
+/*! 
+ * numeral.js language configuration
+ * language : swedish
+ * author : Alex Schenkman : https://github.com/alesch
+ */
+(function () {
+    var language = {
+        delimiters: {
+            thousands: '.',
+            decimal: ','
+        },
+        abbreviations: {
+            thousand: 'k',
+            million: 'm',
+            billion: 'b',
+            trillion: 't'
+        },
+        ordinal: function (number) {
+            var b = number % 10;
+            return (b === 1 || b === 2) ? ':a' : ':e';
+        },
+        currency: {
+            symbol: 'kr'
+        }
+    };
+
+    // Node
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = language;
+    }
+    // Browser
+    if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
+        this.numeral.language('sv', language);
+    }
+}());

--- a/tests/languages/sv.js
+++ b/tests/languages/sv.js
@@ -1,0 +1,103 @@
+var numeral = require('../../numeral'),
+    language = require('../../languages/sv');
+
+numeral.language('sv', language);
+
+exports['language:sv'] = {
+    setUp: function (callback) {
+        numeral.language('sv');
+        callback();
+    },
+
+    tearDown: function (callback) {
+        numeral.language('en');
+        callback();
+    },
+
+    format: function (test) {
+        test.expect(16);
+
+        var tests = [
+            [10000,'0,0.0000','10.000,0000'],
+            [10000.23,'0,0','10.000'],
+            [-10000,'0,0.0','-10.000,0'],
+            [10000.1234,'0.000','10000,123'],
+            [-10000,'(0,0.0000)','(10.000,0000)'],
+            [-0.23,'.00','-,23'],
+            [-0.23,'(.00)','(,23)'],
+            [0.23,'0.00000','0,23000'],
+            [1230974,'0.0a','1,2m'],
+            [1460,'0a','1k'],
+            [-104000,'0a','-104k'],
+            [1,'0o','1:a'],
+            [52,'0o','52:a'],
+            [23,'0o','23:e'],
+            [100,'0o','100:e'],
+            [1,'0[.]0','1']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    currency: function (test) {
+        test.expect(4);
+
+        var tests = [
+            [1000.234,'0,0.00$','1.000,23kr'],
+            [-1000.234,'(0,0$)','(1.000kr)'],
+            [-1000.234,'0.00$','-1000,23kr'],
+            [1230974,'(0.00a$)','1,23mkr']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    percentages: function (test) {
+        test.expect(4);
+
+        var tests = [
+            [1,'0%','100%'],
+            [0.974878234,'0.000%','97,488%'],
+            [-0.43,'0%','-43%'],
+            [0.43,'(0.000%)','43,000%']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    unformat: function (test) {
+        test.expect(9);
+
+        var tests = [
+            ['10.000,123',10000.123],
+            ['(0,12345)',-0.12345],
+            ['(1,23mkr)',-1230000],
+            ['10k',10000],
+            ['-10k',-10000],
+            // Unformatting a swedish ordinal breaks,
+            // as unformatNumeral mistakes the number for a date.
+            ['23',23],  // should be ['23:e', 23]
+            ['10.000,00kr',10000],
+            ['-76%',-0.76],
+            ['2:23:57',8637]
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numeral().unformat(tests[i][0]), tests[i][1], tests[i][0]);
+        }
+
+        test.done();
+    }
+};


### PR DESCRIPTION
Adding Swedish language.

Please note that unformating an ordinal does not work with the current implementation of unformatNumeral().
Swedish ordinals use :a and :e, and unformatNumeral() expects strings containing colon to be time stamps.
