### PR TITLE
fix language key

### DIFF
--- a/languages/es-ES.js
+++ b/languages/es-ES.js
@@ -34,6 +34,6 @@
     }
     // Browser
     if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
-        this.numeral.language('es', language);
+        this.numeral.language('es-ES', language);
     }
 }());


### PR DESCRIPTION
Should be registered as `es-ES`, if you load all languages.js in your app and want to change between different Spanish speaking countries, `es` will be overwritten.