### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,7 @@
   "bugs": {
     "url": "https://github.com/adamwdraper/Numeral-js/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license": "MIT",
   "devDependencies": {
     "uglify-js": "latest",
     "grunt": "latest",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
