### PR TITLE
Updated de.js

### DIFF
--- a/languages/de.js
+++ b/languages/de.js
@@ -6,14 +6,14 @@
 (function () {
     var language = {
         delimiters: {
-            thousands: ' ',
+            thousands: '.',
             decimal: ','
         },
         abbreviations: {
-            thousand: 'k',
-            million: 'm',
-            billion: 'b',
-            trillion: 't'
+            thousand: 'Tds.',
+            million: 'Mio.',
+            billion: 'Mrd.',
+            trillion: 'Bio.'
         },
         ordinal: function (number) {
             return '.';


### PR DESCRIPTION
Set abbrevations.
Set delimiters.
Billion is in german Milliarde, since the long scale is used in German.
https://en.wikipedia.org/wiki/Long_and_short_scales#Long_scale_users
