### PR TITLE
Create fr-CA-fem.js

### DIFF
--- a/languages/fr-CA-fem.js
+++ b/languages/fr-CA-fem.js
@@ -1,0 +1,35 @@
+/*!
+ * numeral.js language configuration
+ * language : french (Canada) (fr-CA)
+ * author : Manuel Darveau : https://github.com/mdarveau
+ * Derived from work by Renaud-Allaire : https://github.com/renaudleo
+ */
+(function () {
+    var language = {
+        delimiters: {
+            thousands: ' ',
+            decimal: ','
+        },
+        abbreviations: {
+            thousand: 'k',
+            million: 'M',
+            billion: 'G',
+            trillion: 'T'
+        },
+        ordinal : function (number) {
+            return number === 1 ? 'ère' : 'ème';
+        },
+        currency: {
+            symbol: '$'
+        }
+    };
+
+    // Node
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = language;
+    }
+    // Browser
+    if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
+        this.numeral.language('fr-CA', language);
+    }
+}());


### PR DESCRIPTION
In French, the ordinal suffix is not the same depending on the "gender" of the word. Such concept does not exist in English... at least not anymore according to Wikipedia!.