### PR TITLE
Correct number delimiters for de-ch language

### DIFF
--- a/languages/de-ch.js
+++ b/languages/de-ch.js
@@ -6,8 +6,8 @@
 (function () {
     var language = {
         delimiters: {
-            thousands: ' ',
-            decimal: ','
+            thousands: '\'',
+            decimal: '.'
         },
         abbreviations: {
             thousand: 'k',


### PR DESCRIPTION
The characters for decimal and thousands delimiters in the Swiss German language were taken from the German (Germany) language and are not accurate for Switzerland.

This PR corrects this.