### PR TITLE
currentLanguage not set in numeral.language

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -429,6 +429,7 @@
 
         if (values || !languages[key]) {
             loadLanguage(key, values);
+            currentLanguage = key;
         }
 
         return numeral;


### PR DESCRIPTION
In a node.js script, when you call:
  var numeral = require('numeral').language('be-nl', require('numeral/languages/be-nl'));
then currentLanguage is not set.

I added a line to correct this. Thanks for checking out this PR!
