### PR TITLE
languages added: en-au and bg

### DIFF
--- a/languages/bg.js
+++ b/languages/bg.js
@@ -1,0 +1,42 @@
+/*! @preserve 
+ * numeral.js language configuration
+ * language : Bulgarian
+ * author : Don Vince : https://github.com/donvince/
+ */
+(function () {
+    var language = {
+        delimiters: {
+            thousands: ' ',
+            decimal: ','
+        },
+        abbreviations: { // I found these here http://www.unicode.org/cldr/charts/28/verify/numbers/bg.html
+            thousand: 'хил',
+            million: 'млн',
+            billion: 'млрд',
+            trillion: 'трлн'
+        },
+        ordinal: function (number) {
+            // google translate suggests:
+            // 1st=1-ви; 2nd=2-ри; 7th=7-ми; 
+            // 8th=8-ми and many others end with -ти 
+            // for example 3rd=3-ти
+            // However since I've seen suggestions that in 
+            // Bulgarian the ordinal can be taken in
+            // different forms (masculine, feminine, neuter)
+            // I've opted to wimp out on commiting that to code
+            return ''; 
+        },
+        currency: {
+            symbol: 'лв'
+        }
+    };
+
+    // Node
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = language;
+    }
+    // Browser
+    if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
+        this.numeral.language('bg', language);
+    }
+}());

--- a/languages/en-au.js
+++ b/languages/en-au.js
@@ -1,0 +1,38 @@
+/*! @preserve 
+ * numeral.js language configuration
+ * language : English Australia
+ * author : Don Vince : https://github.com/donvince/
+ */
+(function () {
+    var language = {
+        delimiters: {
+            thousands: ',',
+            decimal: '.'
+        },
+        abbreviations: {
+            thousand: 'k',
+            million: 'm',
+            billion: 'b',
+            trillion: 't'
+        },
+        ordinal: function (number) {
+            var b = number % 10;
+            return (~~ (number % 100 / 10) === 1) ? 'th' :
+                (b === 1) ? 'st' :
+                (b === 2) ? 'nd' :
+                (b === 3) ? 'rd' : 'th';
+        },
+        currency: {
+            symbol: '$'
+        }
+    };
+
+    // Node
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = language;
+    }
+    // Browser
+    if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
+        this.numeral.language('en-au', language);
+    }
+}());

--- a/tests/languages/bg.js
+++ b/tests/languages/bg.js
@@ -1,0 +1,96 @@
+// Node
+if (typeof module !== 'undefined' && module.exports) {
+    var numeral = require('../../numeral');
+    var expect = require('chai').expect;
+    var language = require('../../languages/bg');
+}
+
+describe('Language: bg', function() {
+
+    before(function() {
+        numeral.language('bg', language);
+
+        numeral.language('bg');
+    });
+
+    after(function() {
+        numeral.reset();
+    });
+
+    describe('Number', function() {
+        it('should format a number', function() {
+            var tests = [
+                [10000,'0,0.0000','10 000,0000'],
+                [10000.23,'0,0','10 000'],
+                [-10000,'0,0.0','-10 000,0'],
+                [10000.1234,'0.000','10000,123'],
+                [-10000,'(0,0.0000)','(10 000,0000)'],
+                [-0.23,'.00','-,23'],
+                [-0.23,'(.00)','(,23)'],
+                [0.23,'0.00000','0,23000'],
+                [1230974,'0.0a','1,2млн'],
+                [1460,'0a','1хил'],
+                [-104000,'0a','-104хил'],
+                [1,'0o','1'],
+                [52,'0o','52'],
+                [23,'0o','23'],
+                [100,'0o','100'],
+                [1,'0[.]0','1']
+            ];
+
+            for (var i = 0; i < tests.length; i++) {
+                expect(numeral(tests[i][0]).format(tests[i][1])).to.equal(tests[i][2]);
+            }
+        });
+    });
+
+    describe('Currency', function() {
+        it('should format a currency', function() {
+            var tests = [
+                [1000.234,'$0,0.00','лв1 000,23'],
+                [-1000.234,'($0,0)','(лв1 000)'],
+                [-1000.234,'$0.00','-лв1000,23'],
+                [1230974,'($0.00a)','лв1,23млн']
+            ];
+
+            for (var i = 0; i < tests.length; i++) {
+                expect(numeral(tests[i][0]).format(tests[i][1])).to.equal(tests[i][2]);
+            }
+        });
+    });
+
+    describe('Percentages', function() {
+        it('should format a percentages', function() {
+            var tests = [
+                [1,'0%','100%'],
+                [0.974878234,'0.000%','97,488%'],
+                [-0.43,'0%','-43%'],
+                [0.43,'(0.000%)','43,000%']
+            ];
+
+            for (var i = 0; i < tests.length; i++) {
+                expect(numeral(tests[i][0]).format(tests[i][1])).to.equal(tests[i][2]);
+            }
+        });
+    });
+
+    describe('Unformat', function() {
+        it('should unformat', function() {
+            var tests = [
+                ['10 000,123',10000.123],
+                ['(0,12345)',-0.12345],
+                ['(лв1,23млн)',-1230000],
+                ['10хил',10000],
+                ['-10хил',-10000],
+                ['23',23],
+                ['лв10 000,00',10000],
+                ['-76%',-0.76],
+                ['2:23:57',8637]
+            ];
+
+            for (var i = 0; i < tests.length; i++) {
+                expect(numeral().unformat(tests[i][0])).to.equal(tests[i][1]);
+            }
+        });
+    });
+});

--- a/tests/languages/en-au.js
+++ b/tests/languages/en-au.js
@@ -1,0 +1,96 @@
+// Node
+if (typeof module !== 'undefined' && module.exports) {
+    var numeral = require('../../numeral');
+    var expect = require('chai').expect;
+    var language = require('../../languages/en-au');
+}
+
+describe('Language: en-au', function() {
+
+    before(function() {
+        numeral.language('en-au', language);
+
+        numeral.language('en-au');
+    });
+
+    after(function() {
+        numeral.reset();
+    });
+
+    describe('Number', function() {
+        it('should format a number', function() {
+            var tests = [
+                [10000,'0,0.0000','10,000.0000'],
+                [10000.23,'0,0','10,000'],
+                [-10000,'0,0.0','-10,000.0'],
+                [10000.1234,'0.000','10000.123'],
+                [-10000,'(0,0.0000)','(10,000.0000)'],
+                [-0.23,'.00','-.23'],
+                [-0.23,'(.00)','(.23)'],
+                [0.23,'0.00000','0.23000'],
+                [1230974,'0.0a','1.2m'],
+                [1460,'0a','1k'],
+                [-104000,'0a','-104k'],
+                [1,'0o','1st'],
+                [52,'0o','52nd'],
+                [23,'0o','23rd'],
+                [100,'0o','100th'],
+                [1,'0[.]0','1']
+            ];
+
+            for (var i = 0; i < tests.length; i++) {
+                expect(numeral(tests[i][0]).format(tests[i][1])).to.equal(tests[i][2]);
+            }
+        });
+    });
+
+    describe('Currency', function() {
+        it('should format a currency', function() {
+            var tests = [
+                [1000.234,'$0,0.00','$1,000.23'],
+                [-1000.234,'($0,0)','($1,000)'],
+                [-1000.234,'$0.00','-$1000.23'],
+                [1230974,'($0.00a)','$1.23m']
+            ];
+
+            for (var i = 0; i < tests.length; i++) {
+                expect(numeral(tests[i][0]).format(tests[i][1])).to.equal(tests[i][2]);
+            }
+        });
+    });
+
+    describe('Percentages', function() {
+        it('should format a percentages', function() {
+            var tests = [
+                [1,'0%','100%'],
+                [0.974878234,'0.000%','97.488%'],
+                [-0.43,'0%','-43%'],
+                [0.43,'(0.000%)','43.000%']
+            ];
+
+            for (var i = 0; i < tests.length; i++) {
+                expect(numeral(tests[i][0]).format(tests[i][1])).to.equal(tests[i][2]);
+            }
+        });
+    });
+
+    describe('Unformat', function() {
+        it('should unformat', function() {
+            var tests = [
+                ['10,000.123',10000.123],
+                ['(0.12345)',-0.12345],
+                ['($1.23m)',-1230000],
+                ['10k',10000],
+                ['-10k',-10000],
+                ['23rd',23],
+                ['$10,000.00',10000],
+                ['-76%',-0.76],
+                ['2:23:57',8637]
+            ];
+
+            for (var i = 0; i < tests.length; i++) {
+                expect(numeral().unformat(tests[i][0])).to.equal(tests[i][1]);
+            }
+        });
+    });
+});


### PR DESCRIPTION
I've added language definitions and accompanying tests for en-au (Australian English) and bg (Bulgarian)