### PR TITLE
change locale ch to a better useful format

### DIFF
--- a/locales/de-ch.js
+++ b/locales/de-ch.js
@@ -13,8 +13,8 @@
 }(this, function (numeral) {
     numeral.register('locale', 'de-ch', {
         delimiters: {
-            thousands: ' ',
-            decimal: ','
+            thousands: "'",
+            decimal: '.'
         },
         abbreviations: {
             thousand: 'k',


### PR DESCRIPTION
In switzerland the most used format is with `'` and `.`