### PR TITLE
Update de-ch locale

### DIFF
--- a/locales/de-ch.js
+++ b/locales/de-ch.js
@@ -13,8 +13,8 @@
 }(this, function (numeral) {
     numeral.register('locale', 'de-ch', {
         delimiters: {
-            thousands: ' ',
-            decimal: ','
+            thousands: '\'',
+            decimal: '.'
         },
         abbreviations: {
             thousand: 'k',


### PR DESCRIPTION
Fix delimiters, thousands and decimal for Swiss German.