### PR TITLE
Correct the delimiters for the swiss language

### DIFF
--- a/locales/de-ch.js
+++ b/locales/de-ch.js
@@ -13,8 +13,8 @@
 }(this, function (numeral) {
     numeral.register('locale', 'de-ch', {
         delimiters: {
-            thousands: ' ',
-            decimal: ','
+            thousands: '\'',
+            decimal: '.'
         },
         abbreviations: {
             thousand: 'k',


### PR DESCRIPTION
I've changed the delimiters cause they are currently in germany style and not in swiss style. In 'fr-ch' it's correct. Only in 'de-ch' it's wrong.