### PR TITLE
Add gender modifier to ordinal fn in PT-BR locale

### DIFF
--- a/locales/pt-br.js
+++ b/locales/pt-br.js
@@ -22,8 +22,8 @@
             billion: 'b',
             trillion: 't'
         },
-        ordinal: function (number) {
-            return 'º';
+        ordinal: function (number, gender = 'm') {
+            return gender === 'm' ? 'º' : 'ª';
         },
         currency: {
             symbol: 'R$'


### PR DESCRIPTION
In `pt-br`, the `ordinal` suffix must agree in gender with its following noun. The current locale only has the `male` ordinal suffix `º`. I added the missing `female` ordinal suffix `ª` and a second argument to the ordinal function. This argument is optional and default to `m`. I then used the ternary operator to return either `º` or `ª`: `return gender === 'm' ? 'º' : 'ª';`.