### PR TITLE
docs: Fix simple typo, avaliable -> available

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -406,13 +406,13 @@
         }
     };
 
-    // avaliable options
+    // available options
     numeral.options = options;
 
-    // avaliable formats
+    // available formats
     numeral.formats = formats;
 
-    // avaliable formats
+    // available formats
     numeral.locales = locales;
 
     // This function sets the current locale.  If

--- a/src/numeral.js
+++ b/src/numeral.js
@@ -406,13 +406,13 @@
         }
     };
 
-    // avaliable options
+    // available options
     numeral.options = options;
 
-    // avaliable formats
+    // available formats
     numeral.formats = formats;
 
-    // avaliable formats
+    // available formats
     numeral.locales = locales;
 
     // This function sets the current locale.  If


### PR DESCRIPTION
There is a small typo in numeral.js, src/numeral.js.

Should read `available` rather than `avaliable`.

