### PR TITLE
fix negative number formatting to a specific precision

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -605,7 +605,7 @@
             return output;
         },
         value: function() {
-            return this._value;
+            return parseFloat(Number.parseFloat(this._value).toPrecision(8));
         },
         input: function() {
             return this._input;

--- a/numeral.js
+++ b/numeral.js
@@ -395,7 +395,10 @@
             power = Math.pow(10, boundedPrecision);
 
             // Multiply up by precision, round accurately, then divide and use native toFixed():
-            output = (roundingFunction(value + 'e+' + boundedPrecision) / power).toFixed(boundedPrecision);
+            output = (roundingFunction(Math.abs(value) + 'e+' + boundedPrecision) / power).toFixed(boundedPrecision);
+            if(value < 0){
+                output = '-' + output
+            }
 
             if (optionals > maxDecimals - boundedPrecision) {
                 optionalsRegExp = new RegExp('\\.?0{1,' + (optionals - (maxDecimals - boundedPrecision)) + '}$');


### PR DESCRIPTION
Fixes #714 

Rounding negative numbers that end with 5 are not similar to positive numbers that end with . So to deal with negative numbers correctly, I first considered them as positive numbers and rounded the numbers and at the end I made the result negative. 