### PR TITLE
fix value() function

### DIFF
--- a/numeral.js
+++ b/numeral.js
@@ -212,14 +212,14 @@
                 int = String(Number(int) / 1000);
 
                 switch (abbr) {
-                    case locale.abbreviations.thousand:
-                        abbr = locale.abbreviations.million;
+                    case ' ' + locale.abbreviations.thousand:
+                        abbr = ' ' + locale.abbreviations.million;
                         break;
-                    case locale.abbreviations.million:
-                        abbr = locale.abbreviations.billion;
+                    case ' ' + locale.abbreviations.million:
+                        abbr = ' ' + locale.abbreviations.billion;
                         break;
-                    case locale.abbreviations.billion:
-                        abbr = locale.abbreviations.trillion;
+                    case ' ' + locale.abbreviations.billion:
+                        abbr = ' ' + locale.abbreviations.trillion;
                         break;
                 }
             }


### PR DESCRIPTION
Fixes #723 

the value() function should not just return the _value attribute. I first make it precise to 8 significant digits and then return the float value of it. This fixes the problem of inaccuracy and losing precision