### PR TITLE
Fix of the currency format on negative numbers rouned to 0

### DIFF
--- a/src/formats/currency.js
+++ b/src/formats/currency.js
@@ -35,7 +35,7 @@
             if (value >= 0) {
                 symbols.before = symbols.before.replace(/[\-\(]/, '');
                 symbols.after = symbols.after.replace(/[\-\)]/, '');
-            } else if (value < 0 && (!numeral._.includes(symbols.before, '-') && !numeral._.includes(symbols.before, '('))) {
+            } else if ((value < 0 && output !== '0') && (!numeral._.includes(symbols.before, '-') && !numeral._.includes(symbols.before, '('))) {
                 symbols.before = '-' + symbols.before;
             }
 


### PR DESCRIPTION
console.log(numeral(-0.008).format('$ 0,0')); -> "0$ "

the code before the change did count with the fact that numberToFormat does not return negative zero (-0)