### PR TITLE
BG Change currency symbol from лв to €

### DIFF
--- a/locales/bg.js
+++ b/locales/bg.js
@@ -34,7 +34,7 @@
             return '';
         },
         currency: {
-            symbol: 'лв'
+            symbol: '€'
         }
     });
 }));


### PR DESCRIPTION
Bulgaria will switch to the euro on January 1, 2026
